### PR TITLE
orgit-rev-store: Update major-mode name

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -181,7 +181,7 @@ If all of the above fails then `orgit-export' raises an error."
           (add-hook 'org-store-link-functions 'orgit-rev-store)))
 
 (defun orgit-rev-store ()
-  (when (eq major-mode 'magit-commit-mode)
+  (when (eq major-mode 'magit-revision-mode)
     (let ((repo (abbreviate-file-name default-directory))
           (rev  (car magit-refresh-args)))
       (org-store-link-props


### PR DESCRIPTION
Commit df088b2 of Magit renamed `magit-commit-mode` to
`magit-revision-mode`.
