### PR TITLE
orgit-log-store: Use branch name, not 'HEAD'

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -159,7 +159,7 @@ If all of the above fails then `orgit-export' raises an error."
 (defun orgit-log-store ()
   (when (eq major-mode 'magit-log-mode)
     (let ((repo (abbreviate-file-name default-directory))
-          (rev  (cadr magit-refresh-args)))
+          (rev  (magit-name-rev (cadr magit-refresh-args))))
       (org-store-link-props
        :type        "orgit-log"
        :link        (format "orgit-log:%s::%s" repo rev)


### PR DESCRIPTION
As you guessed in #1, orgit works with Magit's master. When trying this out on master, I noticed that orgit-log points to HEAD instead of a branch name (like it does with on next). There might be a motivation or use case that I'm not thinking of, but pointing to a branch name seems like a better default for a log link. What do you think?

Also, I've pushed a next branch to kyleam/orgit with the commit from #1 and an additional change for using orgit with Magit's next. 