### PR TITLE
orgit-rev-store: only resolve rev with prefix argument

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -190,10 +190,14 @@ If all of the above fails then `orgit-export' raises an error."
 
 ;;;###autoload
 (defun orgit-rev-store ()
+  "Store a link to a Magit-Revision mode buffer.
+With a prefix argument instead store the name of the branch that
+points at the revision, if any."
   (when (eq major-mode 'magit-revision-mode)
     (let ((repo (abbreviate-file-name default-directory))
           (rev  (car magit-refresh-args)))
-      (unless (magit-ref-p rev)
+      (unless (and current-prefix-arg
+                   (magit-ref-p rev))
         (setq rev (magit-rev-abbrev rev)))
       (org-store-link-props
        :type        "orgit-rev"


### PR DESCRIPTION
Re #12.

I think it sometimes makes sense to link to a branch as in "we use `master` for development". But in most cases the hash is more useful, probably. So that should be the default. Luckily `org-store-link`'s doc-string mentions that we could use a prefix argument to store a different link:

> For some link types, a prefix ARG is interpreted.

This commit implements that.

We should still document that somewhere.