### PR TITLE
Autoload orgit-link-set-parameters

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -65,6 +65,7 @@
 (require 'magit)
 (require 'org)
 
+;;;###autoload
 (defun orgit-link-set-parameters (type &rest parameters)
   (if (fboundp 'org-link-set-parameters) ; since v9.0
       (apply  #'org-link-set-parameters type parameters)


### PR DESCRIPTION
This function is being used in an `eval-after-load 'org` sexp, which itself is autoloaded, which means that `orgit.el` is not guaranteed to be loaded when this function is called.