### PR TITLE
eval-after-load: replace string feature w/ symbol

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -217,7 +217,7 @@ then store a link to the commit itself."
 ;;; Command
 
 ;;;###autoload
-(eval-after-load "magit"
+(eval-after-load 'magit
   '(define-key magit-mode-map [remap org-store-link] 'orgit-store-link))
 
 ;;;###autoload
@@ -237,7 +237,7 @@ then store a link to the commit itself."
 ;;; Status
 
 ;;;###autoload
-(eval-after-load "org"
+(eval-after-load 'org
   '(orgit-link-set-parameters "orgit"
                               :store    'orgit-status-store
                               :follow   'orgit-status-open
@@ -272,7 +272,7 @@ In that case `orgit-rev-store' stores one or more links instead."
 ;;; Log
 
 ;;;###autoload
-(eval-after-load "org"
+(eval-after-load 'org
   '(orgit-link-set-parameters "orgit-log"
                               :store    'orgit-log-store
                               :follow   'orgit-log-open
@@ -327,7 +327,7 @@ In that case `orgit-rev-store' stores one or more links instead."
 ;;; Revision
 
 ;;;###autoload
-(eval-after-load "org"
+(eval-after-load 'org
   '(orgit-link-set-parameters "orgit-rev"
                               :store    'orgit-rev-store
                               :follow   'orgit-rev-open


### PR DESCRIPTION
This is a minor optimization.

TL;DR Given `(eval-after-load FILE FORM)`, `eval-after-load` is less efficient if FILE is a string than when it's a symbol.

When FILE is a string, `eval-after-load` creates a regexp entry in `after-load-alist` that Emacs uses to scan the path of *every* file it loads, and continues to do so after FILE is loaded.

```lisp
 ("\\(\\`\\|/\\)evil\\(\\.elc\\|\\.el\\|\\.so\\)?\\(\\.gz\\)?\\'"
  (closure
   (t)
   nil
   (message "hi")))
```

When FILE is a symbol, there is no such aggressive lookup behavior. It isn't looked up (nor is FORM executed) until a (provide 'FILE) is evaluated in the target package.