### PR TITLE
orgit: Respect orgit-store-repository-id in complete commands

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -271,7 +271,7 @@ In that case `orgit-rev-store' stores one or more links instead."
 
 ;;;###autoload
 (defun orgit-status-complete-link (&optional arg)
-  (concat "orgit:" (abbreviate-file-name (magit-read-repository arg))))
+  (concat "orgit:" (orgit--repository-id (magit-read-repository arg))))
 
 ;;; Log
 
@@ -334,7 +334,7 @@ In that case `orgit-rev-store' stores one or more links instead."
 (defun orgit-log-complete-link (&optional arg)
   (let ((default-directory (magit-read-repository arg)))
     (format "orgit-log:%s::%s"
-            (abbreviate-file-name default-directory)
+            (orgit--repository-id default-directory)
             (magit-read-branch-or-commit "Revision"))))
 
 ;;; Revision
@@ -395,7 +395,7 @@ store links to the Magit-Revision mode buffers for these commits."
 (defun orgit-rev-complete-link (&optional arg)
   (let ((default-directory (magit-read-repository arg)))
     (format "orgit-rev:%s::%s"
-            (abbreviate-file-name default-directory)
+            (orgit--repository-id default-directory)
             (magit-read-branch-or-commit "Revision"))))
 
 ;;; Export
@@ -442,10 +442,15 @@ store links to the Magit-Revision mode buffers for these commits."
 
 ;;; Utilities
 
-(defun orgit--current-repository ()
+(defun orgit--repository-id (&optional dir)
+  (unless dir
+    (setq dir default-directory))
   (or (and orgit-store-repository-id
-           (car (rassoc default-directory (magit-repos-alist))))
-      (abbreviate-file-name default-directory)))
+           (car (rassoc dir (magit-repos-alist))))
+      (abbreviate-file-name dir)))
+
+(defun orgit--current-repository ()
+  (orgit--repository-id default-directory))
 
 (defun orgit--repository-directory (repo)
   (let ((dir (or (cdr (assoc repo (magit-repos-alist)))


### PR DESCRIPTION
Closes #37

Added a new `orgit--repository-id` function which conditionally strips out the path component of a repository directory based on `orgit-store-repository-id`. This is then used in each of the defined link types which previously stored the full path to the repository.