### PR TITLE
Export repository-ID based links

### DIFF
--- a/orgit.el
+++ b/orgit.el
@@ -404,7 +404,7 @@ store links to the Magit-Revision mode buffers for these commits."
 
 (defun orgit-export (path desc format gitvar idx)
   (pcase-let* ((`(,dir ,rev) (split-string path "::"))
-               (dir (file-name-as-directory (expand-file-name dir))))
+               (dir (orgit--repository-directory dir)))
     (if (file-exists-p dir)
         (let* ((default-directory dir)
                (remotes (magit-git-lines "remote"))


### PR DESCRIPTION
Without this fix, export fails because one needs to parse the "shorten" repository locations back to full paths.
More concretely, these links fail to be exported with the following message: 

```elisp
"Cannot determine public url for %s %s" path "(which itself does not exist)"
```

where `orgit-store-repository-id` is non-nil.